### PR TITLE
"ESPHome 2025.11 changed esphome::network::get_use_address() to retur…

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,11 @@ Usage
 -----
 
 Requires ESPHome v2022.3.0 or newer.
+Just Adapted to ESPHome 2026.2.x
 
 ```yaml
 external_components:
-  - source: github://Pluimvee/esphome-modbus-tcp-to-rtu
+  - source: github://seppelw/esphome-modbus-tcp-to-rtu
 
 modbus_bridge:
 ```

--- a/components/modbus_bridge/modbus_bridge.cpp
+++ b/components/modbus_bridge/modbus_bridge.cpp
@@ -81,7 +81,29 @@ void ModBusBridgeComponent::accept()
         return;
 
     socket->setblocking(false);
-    std::string identifier = socket->getpeername();
+    //std::string identifier = socket->getpeername();
+
+    struct sockaddr_storage storage;
+    socklen_t len = sizeof(storage);
+    socket->getpeername((struct sockaddr*)&storage, &len);
+    std::string identifier;
+
+    char str[INET6_ADDRSTRLEN];
+        if (storage.ss_family == AF_INET) {
+            struct sockaddr_in *addr = (struct sockaddr_in *)&storage;
+            inet_ntop(AF_INET, &(addr->sin_addr), str, INET_ADDRSTRLEN);
+            identifier = std::string(str);
+            }
+       else if (storage.ss_family == AF_INET6) {
+            struct sockaddr_in6 *addr = (struct sockaddr_in6 *)&storage;
+            inet_ntop(AF_INET6, &(addr->sin6_addr), str, INET6_ADDRSTRLEN);
+            identifier = std::string(str);
+        }
+       else {
+            identifier = "Unknown";
+        }
+
+
     this->clients_.emplace_back(std::move(socket), identifier);
     ESP_LOGI(TAG, "New client connected from %s", identifier.c_str());
     this->publish_sensor();

--- a/components/modbus_bridge/modbus_bridge.cpp
+++ b/components/modbus_bridge/modbus_bridge.cpp
@@ -40,7 +40,7 @@ void ModBusBridgeComponent::loop() {
 /////////////////////////////////////////////////////////////////////////////////////////////////////////////
 void ModBusBridgeComponent::dump_config() {
     ESP_LOGCONFIG(TAG, "ModBus Bridge:");
-    ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address().c_str(), this->port_);
+    ESP_LOGCONFIG(TAG, "  Address: %s:%u", esphome::network::get_use_address(), this->port_);
     ESP_LOGCONFIG(TAG, "  ModBus timeout: %d ms", this->timeout_);
     ESP_LOGCONFIG(TAG, "  UART buffer: %d bytes", this->buf_size_);
 #ifdef USE_BINARY_SENSOR

--- a/components/modbus_bridge/modbus_bridge.cpp
+++ b/components/modbus_bridge/modbus_bridge.cpp
@@ -81,27 +81,14 @@ void ModBusBridgeComponent::accept()
         return;
 
     socket->setblocking(false);
-    //std::string identifier = socket->getpeername();
-
     struct sockaddr_storage storage;
     socklen_t len = sizeof(storage);
     socket->getpeername((struct sockaddr*)&storage, &len);
-    std::string identifier;
+    std::string identifier = socket->getpeername();
 
-    char str[INET6_ADDRSTRLEN];
-        if (storage.ss_family == AF_INET) {
-            struct sockaddr_in *addr = (struct sockaddr_in *)&storage;
-            inet_ntop(AF_INET, &(addr->sin_addr), str, INET_ADDRSTRLEN);
-            identifier = std::string(str);
-            }
-       else if (storage.ss_family == AF_INET6) {
-            struct sockaddr_in6 *addr = (struct sockaddr_in6 *)&storage;
-            inet_ntop(AF_INET6, &(addr->sin6_addr), str, INET6_ADDRSTRLEN);
-            identifier = std::string(str);
-        }
-       else {
-            identifier = "Unknown";
-        }
+    this->clients_.emplace_back(std::move(socket), identifier);
+    ESP_LOGI(TAG, "New client connected from %s", identifier.c_str());
+    this->publish_sensor();
 
 
     this->clients_.emplace_back(std::move(socket), identifier);

--- a/components/modbus_bridge/modbus_bridge.cpp
+++ b/components/modbus_bridge/modbus_bridge.cpp
@@ -81,15 +81,11 @@ void ModBusBridgeComponent::accept()
         return;
 
     socket->setblocking(false);
-    struct sockaddr_storage storage;
-    socklen_t len = sizeof(storage);
-    socket->getpeername((struct sockaddr*)&storage, &len);
-    std::string identifier = socket->getpeername();
 
-    this->clients_.emplace_back(std::move(socket), identifier);
-    ESP_LOGI(TAG, "New client connected from %s", identifier.c_str());
-    this->publish_sensor();
-
+    
+    char peername[esphome::socket::SOCKADDR_STR_LEN];
+    socket->getpeername_to(peername);
+    std::string identifier = peername;
 
     this->clients_.emplace_back(std::move(socket), identifier);
     ESP_LOGI(TAG, "New client connected from %s", identifier.c_str());


### PR DESCRIPTION
ESPHome 2025.11 changed esphome::network::get_use_address() to return const char* instead of std::string. Calling .c_str() on it causes a compilation error. The fix is to remove .c_str() from the logging statement in modbus_bridge.cpp."